### PR TITLE
Fix minor typo in HSM Extension

### DIFF
--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -774,7 +774,7 @@ the state machine shown below in the <<figure_hsm>>.
 .SBI HSM State Machine
 image::riscv-sbi-hsm.png[]
 
-A platform can have multiple harts grouped into a hierarchical topology
+A platform can have multiple harts grouped into hierarchical topology
 groups (namely cores, clusters, nodes, etc) with separate platform specific
 low-power states for each hierarchical group. These platform specific
 low-power states of hierarchical topology groups can be represented as


### PR DESCRIPTION
Update 'a hierarchical topology groups' to 'hierarchical topology
groups'.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>