### PR TITLE
Mention RV32 integer model

### DIFF
--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -114,6 +114,8 @@ returning an error code. This is analogous to returning the C structure
     };
 ----
 
+Where RV64 uses the LP64 integer model that defines `long` to be 64 bit.
+
 The <<table_standard_sbi_errors>> below provides a list of Standard SBI
 error codes.
 

--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -114,7 +114,8 @@ returning an error code. This is analogous to returning the C structure
     };
 ----
 
-Where RV64 uses the LP64 integer model that defines `long` to be 64 bit.
+Where RV64 uses the LP64 integer model that defines `long` to be 64 bit and
+RV32 uses ILP32 that defines `long` to be 32 bit.
 
 The <<table_standard_sbi_errors>> below provides a list of Standard SBI
 error codes.

--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -84,9 +84,10 @@ image::riscv-sbi-intro2.png[width=800,height=350]
 
 All SBI functions share a single binary encoding, which facilitates the mixing
 of SBI extensions. This binary encoding matches the RISC-V Linux syscall ABI,
-which itself is based on the calling convention defined in the RISC-V ELF
-psABI. In other words, SBI calls are exactly the same as standard RISC-V
-function calls except that:
+which itself is based on the calling convention defined in the
+https://github.com/riscv/riscv-elf-psabi-doc[RISC-V ELF psABI Specification].
+In other words, SBI calls are exactly the same as standard RISC-V function calls
+except that:
 
 * An `ECALL` is used as the control transfer instruction instead of a `CALL`
   instruction.


### PR DESCRIPTION
This PR is on top of https://github.com/riscv-non-isa/riscv-sbi-doc/pull/87, because @atishp04 mentioned in comment https://github.com/riscv-non-isa/riscv-sbi-doc/pull/87#pullrequestreview-858740241 that RV32 is not to be ratified yet.