### PR TITLE
Update the calling convention

### DIFF
--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -130,26 +130,20 @@ discovery methods (i.e. Device Tree or ACPI) for that.
 == Binary Encoding
 
 All SBI functions share a single binary encoding, which facilitates the mixing
-of SBI extensions. This binary encoding matches the RISC-V Linux syscall ABI,
-which itself is based on the calling convention defined in the RISC-V ELF
-psABI. In other words, SBI calls are exactly the same as standard RISC-V
-function calls except that:
+of SBI extensions. The SBI specification follows the below calling convention.
 
-* An `ECALL` is used as the control transfer instruction instead of a `CALL`
-  instruction.
+* An `ECALL` is used as the control transfer instruction between the supervisor
+  and the SEE.
+
 * `a7` encodes the SBI extension ID (*EID*),
-  which matches how the system call ID is encoded in Linux system call ABI.
 
-Many SBI extensions also chose to encode an additional SBI function ID (*FID*)
-in `a6`, a scheme similar to the `ioctl()` system call on many UNIX operating
-systems. This allows SBI extensions to encode multiple functions within the
-space of a single extension.
+* `a6` encodes the SBI function ID (*FID*) for a given extension ID encoded
+   in `a7` for any SBI extension defined in or after SBI v0.2.
 
-In the name of compatibility, SBI extension IDs (*EIDs*) and SBI function IDs
-(*FIDs*) are encoded as signed 32-bit integers. When passed in registers these
-follow the standard RISC-V calling convention rules.
+* All registers except `a0` & `a1` must be preserved across an SBI call by the
+  callee.
 
-SBI functions must return a pair of values in `a0` and `a1`, with `a0`
+* SBI functions must return a pair of values in `a0` and `a1`, with `a0`
 returning an error code. This is analogous to returning the C structure
 
 [source, C]
@@ -159,6 +153,10 @@ returning an error code. This is analogous to returning the C structure
         long value;
     };
 ----
+
+In the name of compatibility, SBI extension IDs (*EIDs*) and SBI function IDs
+(*FIDs*) are encoded as signed 32-bit integers. When passed in registers these
+follow the standard above calling convention rules.
 
 The <<table_standard_sbi_errors>> below provides a list of Standard SBI
 error codes.


### PR DESCRIPTION
SBI specification calling convention can not refer to the syscall or
psABI calling convention because of the current implementation
FreeBSD/Linux precludes that.

Moreover, all the major SBI implementations  KVM, Xvisor) saves
all the registers (except a0 & a1) anyways.

Update the calling convention to reflect that.

Signed-off-by: Atish Patra <atishp@rivosinc.com>