### PR TITLE
Fix typo in the PMU Extension

### DIFF
--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -1542,7 +1542,7 @@ shown in the <<table_pmu_counter_cfg_match_errors>> below.
 | SBI_ERR_NOT_SUPPORTED | none of the counters can monitor specified event.
 |===
 
-=== Function: Start a set of counters (FID #4)
+=== Function: Start a set of counters (FID #3)
 
 [source, C]
 ----


### PR DESCRIPTION
Update 'FID #4' to 'FID #3' for the function 'Start
a set of counters'.

Signed-off-by: Yiting Wang <yiting.wang@windriver.com>