### PR TITLE
fix: ambiguous and invisible characters

### DIFF
--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -140,7 +140,7 @@ image::riscv-sbi-intro1.png[width=524,height=218]
 .RISC-V System with H-extension
 image::riscv-sbi-intro2.png[width=800,height=350]
 
-The SBI specification doesn’t specify any method for hardware discovery.
+The SBI specification doesn't specify any method for hardware discovery.
 The supervisor software must rely on the other industry standard hardware
 discovery methods (i.e. Device Tree or ACPI) for that.
 
@@ -264,8 +264,8 @@ the SBI implementation (or higher privilege mode), then this physical memory
 address range MUST satisfy the following requirements:
 
 * The SBI implementation MUST check that the supervisor-mode software is
-  allowed to access the specified physical memory range with the access
-  type requested (read and/or write).
+  allowed to access the specified physical memory range with the access
+  type requested (read and/or write).
 * The SBI implementation MUST access the specified physical memory range
   using the PMA attributes.
   *NOTE:* If the supervisor-mode software accesses the same physical memory
@@ -1920,8 +1920,8 @@ by that of the extension.
 [cols="1,1,2", width=90%, align="center", options="header"]
 |===
 | Type                    | Name           | Description
-| 0                       | SUSPEND_TO_RAM | This is a “suspend to RAM”
-                                             sleep type, similar to ACPI’s
+| 0                       | SUSPEND_TO_RAM | This is a "suspend to RAM"
+                                             sleep type, similar to ACPI's
                                              S2 or S3. Entry requires all
                                              but the calling hart be in the
                                              HSM `STOPPED` state and all hart


### PR DESCRIPTION
This pull request fixes some characters that may be causing confusion or not showing up correctly:

- Replaces ’ with '
- Replaces “” with "
- Replaces non-breaking spaces (\u00A0) with regular spaces (\u0020)