### PR TITLE
Add Hart Software Services SBI Implementation ID

### DIFF
--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -408,6 +408,7 @@ value for this CSR.
 | 5                 | Diosix
 | 6                 | Coffer
 | 7                 | Xen Project
+| 8                 | PolarFire Hart Software Services
 |===
 
 == Legacy Extensions (EIDs #0x00 - #0x0F)


### PR DESCRIPTION
The Hart Software Services (HSS), used on PolarFire SoC, is based on OpenSBI, but OpenSBI comprises only a small fraction of the codebase, as the HSS only builds the select files that it needs due to heavy restrictions on code size.
It also does not run out of regular system memory, thereby avoiding issues with reserved-memory regions that affect many versions of OpenSBI.

Give it its own implementation ID so that supervisor mode software can differentiate it from regular OpenSBI.

Link: https://github.com/polarfire-soc/hart-software-services/