### PR TITLE
Various cleanups

### DIFF
--- a/src/changelog.adoc
+++ b/src/changelog.adoc
@@ -5,6 +5,8 @@
 * Return error code SBI_ERR_NO_SHMEM in SBI PMU extension wherever applicable
 * Made flags parameter of sbi_steal_time_set_shmem() as unsigned long
 * Split the specification into multiple adoc files
+* Add more clarification for firmware/vendor/experimental extension space.
+* Fix ambiguous usage of normative statements. 
 
 === Version 2.0-rc3
 * CI support added

--- a/src/ext-experimental.adoc
+++ b/src/ext-experimental.adoc
@@ -1,3 +1,4 @@
 == Experimental SBI Extension Space (EIDs #0x08000000 - #0x08FFFFFF)
 
-No management.
+The SBI specification doesn't define any rules for the EID management for
+experimental SBI extensions.

--- a/src/ext-firmware.adoc
+++ b/src/ext-firmware.adoc
@@ -1,5 +1,6 @@
 == Firmware Specific Extension Space (EIDs #0x0A000000 - #0x0AFFFFFF)
 
-Low bits is SBI implementation ID. The firmware specific SBI extensions are
-for SBI implementations. It provides firmware specific SBI functions which
-are defined in the external firmware specification.
+The lower 24 bits of the firmware EID must match the lower 24 bits of the SBI
+implementation ID. The firmware specific SBI extensions space is reserved for
+SBI implementations. It provides firmware specific SBI functions which are
+defined in the external firmware specification.

--- a/src/ext-nested-acceleration.adoc
+++ b/src/ext-nested-acceleration.adoc
@@ -41,7 +41,7 @@ To use the SBI nested acceleration extension, the supervisor software
 physical address for each virtual hart at boot-time. The physical base
 address of the nested acceleration shared memory MUST be 4096 bytes
 (i.e. page) aligned and the size of the nested acceleration shared
-memory is assumed to be `4096 + (1024 * (XLEN / 8))` bytes. The
+memory must be `4096 + (1024 * (XLEN / 8))` bytes. The
 <<table_nacl_shmem_layout>> below shows the layout of nested
 acceleration shared memory.
 
@@ -163,7 +163,7 @@ bit set. After processing pending nested HFENCE entries, the SBI implementation
                        &nbsp;&nbsp;&nbsp;&nbsp;BIT[29:16] - VMID +
                        &nbsp;&nbsp;&nbsp;&nbsp;BIT[15:0] - ASID +
                        +
-                       The page size for invalidation is assumed to be +
+                       The page size for invalidation must be +
                        `1 << (Config.Order + 12)` bytes.
 | 1    | Page_Number | Page address right shifted by `Config.Order + 12`
 | 2    | Reserved    | Reserved for future use and must be zero
@@ -376,7 +376,7 @@ If both `shmem_phys_lo` and `shmem_phys_hi` parameters are not all-ones
 bitwise then `shmem_phys_lo` specifies the lower XLEN bits and `shmem_phys_hi`
 specifies the upper XLEN bits of the shared memory physical base address.
 `shmem_phys_lo` MUST be 4096 bytes (i.e. page) aligned and the size of the
-shared memory is assumed to be `4096 + (XLEN * 128)` bytes.
+shared memory must be `4096 + (XLEN * 128)` bytes.
 
 If both `shmem_phys_lo` and `shmem_phys_hi` parameters are all-ones bitwise
 then the nested acceleration features are disabled.

--- a/src/ext-pmu.adoc
+++ b/src/ext-pmu.adoc
@@ -521,7 +521,7 @@ If both `shmem_phys_lo` and `shmem_phys_hi` parameters are not all-ones
 bitwise then `shmem_phys_lo` specifies the lower XLEN bits and `shmem_phys_hi`
 specifies the upper XLEN bits of the snapshot shared memory physical base
 address. The `shmem_phys_lo` MUST be 4096 bytes (i.e. page) aligned and
-the size of the snapshot shared memory is assumed to be 4096 bytes. The layout
+the size of the snapshot shared memory must be 4096 bytes. The layout
 of the snapshot shared memory is described in <<table_snapshot_shmem_layout>>.
 
 If both `shmem_phys_lo` and `shmem_phys_hi` parameters are all-ones bitwise

--- a/src/ext-steal-time.adoc
+++ b/src/ext-steal-time.adoc
@@ -28,9 +28,9 @@ reporting.
 If `shmem_phys_lo` and `shmem_phys_hi` are not all-ones bitwise, then
 `shmem_phys_lo` specifies the lower XLEN bits and `shmem_phys_hi` specifies the
 upper XLEN bits of the shared memory physical base address. `shmem_phys_lo`
-MUST be 64-byte aligned. The size of the shared memory is assumed to be at
-least 64 bytes. All bytes MUST be set to zero by the SBI implementation before
-returning from the SBI call.
+MUST be 64-byte aligned. The size of the shared memory must be at least 64
+bytes. All bytes MUST be set to zero by the SBI implementation before returning
+from the SBI call.
 
 If `shmem_phys_lo` and `shmem_phys_hi` are all-ones bitwise, the SBI
 implementation will stop reporting steal-time information for the virtual hart.

--- a/src/ext-vendor.adoc
+++ b/src/ext-vendor.adoc
@@ -1,3 +1,4 @@
 == Vendor Specific Extension Space (EIDs #0x09000000 - #0x09FFFFFF)
 
-Low bits from `mvendorid`.
+The lower 24 bits of vendor specific EID must match the lower 24 bits of the
+`mvendorid` value. 


### PR DESCRIPTION
There are usage of "is assumed to be" for normative statements. The meaning of it subjective and ambiguous. As the the intention was to use normative verbs anyways, lets just use "must" to provide more clarification.