### PR TITLE
Fix the wording for remote fence address ranges

### DIFF
--- a/src/ext-legacy.adoc
+++ b/src/ext-legacy.adoc
@@ -121,6 +121,11 @@ long sbi_remote_sfence_vma(const unsigned long *hart_mask,
 Instructs the remote harts to execute one or more `SFENCE.VMA` instructions,
 covering the range of virtual addresses between `start` and `start + size`.
 
+The remote fence operation applies to the entire address space if either:
+
+* `start` and `size` are both 0, or
+* `size` is equal to 2^XLEN-1.
+
 This SBI call returns 0 upon success or an implementation specific negative
 error code.
 
@@ -137,6 +142,11 @@ long sbi_remote_sfence_vma_asid(const unsigned long *hart_mask,
 Instruct the remote harts to execute one or more `SFENCE.VMA` instructions,
 covering the range of virtual addresses between `start` and `start + size`.
 This covers only the given `ASID`.
+
+The remote fence operation applies to the entire address space if either:
+
+* `start` and `size` are both 0, or
+* `size` is equal to 2^XLEN-1.
 
 This SBI call returns 0 upon success or an implementation specific negative
 error code.

--- a/src/ext-legacy.adoc
+++ b/src/ext-legacy.adoc
@@ -119,7 +119,7 @@ long sbi_remote_sfence_vma(const unsigned long *hart_mask,
 ----
 
 Instructs the remote harts to execute one or more `SFENCE.VMA` instructions,
-covering the range of virtual addresses between start and size.
+covering the range of virtual addresses between `start` and `start + size`.
 
 This SBI call returns 0 upon success or an implementation specific negative
 error code.
@@ -135,8 +135,8 @@ long sbi_remote_sfence_vma_asid(const unsigned long *hart_mask,
 ----
 
 Instruct the remote harts to execute one or more `SFENCE.VMA` instructions,
-covering the range of virtual addresses between start and size. This covers
-only the given `ASID`.
+covering the range of virtual addresses between `start` and `start + size`.
+This covers only the given `ASID`.
 
 This SBI call returns 0 upon success or an implementation specific negative
 error code.

--- a/src/ext-rfence.adoc
+++ b/src/ext-rfence.adoc
@@ -2,14 +2,14 @@
 
 This extension defines all remote fence related functions and replaces
 the legacy extensions (EIDs #0x05 - #0x07). All the functions follow the
-`hart_mask` as defined in binary encoding section. Any function wishes
-to use range of addresses (i.e. start_addr and size), have to abide by
+`hart_mask` as defined in binary encoding section. Any function which
+accepts a range of addresses (i.e. `start_addr` and `size`) must abide by
 the below constraints on range parameters.
 
-The remote fence function acts as a full TLB flush if
+The remote fence operation applies to the entire address space if either:
 
-* `start_addr` and `size` are both 0
-* `size` is equal to 2^XLEN-1
+* `start_addr` and `size` are both 0, or
+* `size` is equal to 2^XLEN-1.
 
 === Function: Remote FENCE.I (FID #0)
 

--- a/src/ext-rfence.adoc
+++ b/src/ext-rfence.adoc
@@ -42,7 +42,7 @@ struct sbiret sbi_remote_sfence_vma(unsigned long hart_mask,
 ----
 
 Instructs the remote harts to execute one or more `SFENCE.VMA` instructions,
-covering the range of virtual addresses between start and size.
+covering the range of virtual addresses between `start` and `start + size`.
 
 The possible error codes returned in `sbiret.error` are shown in the
 <<table_rfence_remote_sfence_vma_errors>> below.
@@ -69,8 +69,8 @@ struct sbiret sbi_remote_sfence_vma_asid(unsigned long hart_mask,
 ----
 
 Instruct the remote harts to execute one or more `SFENCE.VMA` instructions,
-covering the range of virtual addresses between start and size. This covers
-only the given `ASID`.
+covering the range of virtual addresses between `start` and `start + size`.
+This covers only the given `ASID`.
 
 The possible error codes returned in `sbiret.error` are shown in the
 <<table_rfence_remote_sfence_vma_asid_errors>> below.
@@ -97,9 +97,9 @@ struct sbiret sbi_remote_hfence_gvma_vmid(unsigned long hart_mask,
 ----
 
 Instruct the remote harts to execute one or more `HFENCE.GVMA` instructions,
-covering the range of guest physical addresses between start and size only
-for the given `VMID`. This function call is only valid for harts implementing
-hypervisor extension.
+covering the range of guest physical addresses between `start` and `start +
+size` only for the given `VMID`. This function call is only valid for harts
+implementing hypervisor extension.
 
 The possible error codes returned in `sbiret.error` are shown in the
 <<table_rfence_remote_hfence_gvma_vmid_errors>> below.
@@ -128,9 +128,9 @@ struct sbiret sbi_remote_hfence_gvma(unsigned long hart_mask,
 ----
 
 Instruct the remote harts to execute one or more `HFENCE.GVMA` instructions,
-covering the range of guest physical addresses between start and size for all
-the guests. This function call is only valid for harts implementing hypervisor
-extension.
+covering the range of guest physical addresses between `start` and `start +
+size` for all the guests. This function call is only valid for harts
+implementing hypervisor extension.
 
 The possible error codes returned in `sbiret.error` are shown in the
 <<table_rfence_remote_hfence_gvma_errors>> below.
@@ -160,9 +160,9 @@ struct sbiret sbi_remote_hfence_vvma_asid(unsigned long hart_mask,
 ----
 
 Instruct the remote harts to execute one or more `HFENCE.VVMA` instructions,
-covering the range of guest virtual addresses between start and size for the
-given `ASID` and current `VMID` (in `hgatp` CSR) of calling hart. This function
-call is only valid for harts implementing hypervisor extension.
+covering the range of guest virtual addresses between `start` and `start +
+size` for the given `ASID` and current `VMID` (in `hgatp` CSR) of calling hart.
+This function call is only valid for harts implementing hypervisor extension.
 
 The possible error codes returned in `sbiret.error` are shown in the
 <<table_rfence_remote_hfence_vvma_asid_errors>> below.
@@ -191,9 +191,9 @@ struct sbiret sbi_remote_hfence_vvma(unsigned long hart_mask,
 ----
 
 Instruct the remote harts to execute one or more `HFENCE.VVMA` instructions,
-covering the range of guest virtual addresses between start and size for
-current `VMID` (in `hgatp` CSR) of calling hart. This function call is only
-valid for harts implementing hypervisor extension.
+covering the range of guest virtual addresses between `start` and `start +
+size` for current `VMID` (in `hgatp` CSR) of calling hart. This function call
+is only valid for harts implementing hypervisor extension.
 
 The possible error codes returned in `sbiret.error` are shown in the
 <<table_rfence_remote_hfence_vvma_errors>> below.

--- a/src/ext-rfence.adoc
+++ b/src/ext-rfence.adoc
@@ -42,7 +42,8 @@ struct sbiret sbi_remote_sfence_vma(unsigned long hart_mask,
 ----
 
 Instructs the remote harts to execute one or more `SFENCE.VMA` instructions,
-covering the range of virtual addresses between `start` and `start + size`.
+covering the range of virtual addresses between `start_addr` and
+`start_addr + size`.
 
 The possible error codes returned in `sbiret.error` are shown in the
 <<table_rfence_remote_sfence_vma_errors>> below.
@@ -69,8 +70,8 @@ struct sbiret sbi_remote_sfence_vma_asid(unsigned long hart_mask,
 ----
 
 Instruct the remote harts to execute one or more `SFENCE.VMA` instructions,
-covering the range of virtual addresses between `start` and `start + size`.
-This covers only the given `ASID`.
+covering the range of virtual addresses between `start_addr` and
+`start_addr + size`. This covers only the given `ASID`.
 
 The possible error codes returned in `sbiret.error` are shown in the
 <<table_rfence_remote_sfence_vma_asid_errors>> below.
@@ -97,9 +98,9 @@ struct sbiret sbi_remote_hfence_gvma_vmid(unsigned long hart_mask,
 ----
 
 Instruct the remote harts to execute one or more `HFENCE.GVMA` instructions,
-covering the range of guest physical addresses between `start` and `start +
-size` only for the given `VMID`. This function call is only valid for harts
-implementing hypervisor extension.
+covering the range of guest physical addresses between `start_addr` and
+`start_addr + size` only for the given `VMID`. This function call is only valid
+for harts implementing hypervisor extension.
 
 The possible error codes returned in `sbiret.error` are shown in the
 <<table_rfence_remote_hfence_gvma_vmid_errors>> below.
@@ -128,9 +129,9 @@ struct sbiret sbi_remote_hfence_gvma(unsigned long hart_mask,
 ----
 
 Instruct the remote harts to execute one or more `HFENCE.GVMA` instructions,
-covering the range of guest physical addresses between `start` and `start +
-size` for all the guests. This function call is only valid for harts
-implementing hypervisor extension.
+covering the range of guest physical addresses between `start_addr` and
+`start_addr + size` for all the guests. This function call is only valid for
+harts implementing hypervisor extension.
 
 The possible error codes returned in `sbiret.error` are shown in the
 <<table_rfence_remote_hfence_gvma_errors>> below.
@@ -160,9 +161,10 @@ struct sbiret sbi_remote_hfence_vvma_asid(unsigned long hart_mask,
 ----
 
 Instruct the remote harts to execute one or more `HFENCE.VVMA` instructions,
-covering the range of guest virtual addresses between `start` and `start +
-size` for the given `ASID` and current `VMID` (in `hgatp` CSR) of calling hart.
-This function call is only valid for harts implementing hypervisor extension.
+covering the range of guest virtual addresses between `start_addr` and
+`start_addr + size` for the given `ASID` and current `VMID` (in `hgatp` CSR) of
+calling hart. This function call is only valid for harts implementing
+hypervisor extension.
 
 The possible error codes returned in `sbiret.error` are shown in the
 <<table_rfence_remote_hfence_vvma_asid_errors>> below.
@@ -191,9 +193,9 @@ struct sbiret sbi_remote_hfence_vvma(unsigned long hart_mask,
 ----
 
 Instruct the remote harts to execute one or more `HFENCE.VVMA` instructions,
-covering the range of guest virtual addresses between `start` and `start +
-size` for current `VMID` (in `hgatp` CSR) of calling hart. This function call
-is only valid for harts implementing hypervisor extension.
+covering the range of guest virtual addresses between `start_addr` and
+`start_addr + size` for current `VMID` (in `hgatp` CSR) of calling hart. This
+function call is only valid for harts implementing hypervisor extension.
 
 The possible error codes returned in `sbiret.error` are shown in the
 <<table_rfence_remote_hfence_vvma_errors>> below.


### PR DESCRIPTION
The two parameters are the start and size of the address range, not the start and end of the range.