### PR TITLE
sbi_system_suspend() cannot return SBI_SUCCESS

### DIFF
--- a/src/ext-sys-suspend.adoc
+++ b/src/ext-sys-suspend.adoc
@@ -90,7 +90,6 @@ The possible error codes returned in `sbiret.error` are shown in
 [cols="1,2", width=100%, align="center", options="header"]
 |===
 | Error code              | Description
-| SBI_SUCCESS             | System has suspended and resumed successfully.
 | SBI_ERR_INVALID_PARAM   | `sleep_type` is reserved or is platform-specific
                             and unimplemented.
 | SBI_ERR_NOT_SUPPORTED   | `sleep_type` is not reserved and is implemented,


### PR DESCRIPTION
If the suspend/resume operation is successful, execution continues at `resume_addr`, as described in the text. The function does not return.

Closes #130 