### PR TITLE
Add coreboot and oreboot extension IDs

### DIFF
--- a/src/ext-base.adoc
+++ b/src/ext-base.adoc
@@ -110,4 +110,6 @@ value for this CSR.
 | 6                 | Coffer
 | 7                 | Xen Project
 | 8                 | PolarFire Hart Software Services
+| 9                 | coreboot
+| 10                | oreboot
 |===


### PR DESCRIPTION
coreboot has had its own SBI since 2015, and
we are in the process of updating it.

oreboot is in the process of creating its own.