### PR TITLE
Add bhyve — FreeBSD-native hypervisor.

### DIFF
--- a/src/ext-base.adoc
+++ b/src/ext-base.adoc
@@ -112,4 +112,5 @@ value for this CSR.
 | 8                 | PolarFire Hart Software Services
 | 9                 | coreboot
 | 10                | oreboot
+| 11                | bhyve
 |===


### PR DESCRIPTION
Support for bhyve/risc-v is not in the tree yet, but the work is in progress and it is able to boot riscv-guest already.