### PR TITLE
Clarify the description of the `set_timer` function

### DIFF
--- a/src/changelog.adoc
+++ b/src/changelog.adoc
@@ -1,6 +1,7 @@
 == Change Log
 
 === Version 3.0-rc1
+* Clarify the description of the `set_timer` function
 * Added SBI DBTR extension
 * Added SBI FWFT extension
 * Added SBI SSE extension

--- a/src/ext-time.adoc
+++ b/src/ext-time.adoc
@@ -11,13 +11,18 @@ struct sbiret sbi_set_timer(uint64_t stime_value)
 ----
 
 Programs the clock for next event after *stime_value* time. *stime_value*
-is in absolute time. This function must clear the pending timer interrupt
-bit as well.
+is in absolute time.
 
 If the supervisor wishes to clear the timer interrupt without scheduling
-the next timer event, it can either request a timer interrupt infinitely
-far into the future (i.e., (uint64_t)-1), or it can instead mask the timer
-interrupt by clearing `sie.STIE` CSR bit.
+the next timer event, it may request a timer interrupt infinitely far
+into the future (i.e., (uint64_t)-1). Alternatively, to not receive timer
+interrupts, it may mask timer interrupts by clearing the `sie.STIE` CSR bit.
+
+This function must clear the pending timer interrupt bit when
+*stime_value* is set to some time in the future, regardless of whether
+timer interrupts are masked or not.
+
+This function always returns SBI_SUCCESS in `sbiret.error`.
 
 === Function Listing
 


### PR DESCRIPTION
Improve the phrasing on the clearing of the pending timer interrupt bit when timer interrupts are masked.

Additionally, clarify that this function can never fail.

CC: @atishp04 @jones-drew 