### PR TITLE
Add POINTER_MASKING_PMLEN to the SBI FWFT extension

### DIFF
--- a/src/ext-firmware-features.adoc
+++ b/src/ext-firmware-features.adoc
@@ -20,7 +20,9 @@ the features which supervisor-mode software may request to set or get.
                                             supervisor-mode.
 | 0x00000004   | PTE_AD_HW_UPDATING       | Control hardware updating of PTE A/D
                                             bits for supervisor-mode.
-| 0x00000005 -
+| 0x00000005   | POINTER_MASKING_PMLEN    | Control the pointer masking tag
+                                            length for supervisor-mode.
+| 0x00000006 -
   0x3fffffff   |                          | Local feature types reserved for
                                             future use.
 | 0x40000000 -
@@ -91,6 +93,13 @@ description. Upon system reset, global and local feature values are reset.
 !===
 ! 0 ! Disable hardware updating of PTE A/D bits for supervisor-mode.
 ! 1 ! Enable hardware updating of PTE A/D bits for supervisor-mode.
+!===
+| POINTER_MASKING_PMLEN                             | 0     | Local |
+[cols="1,4"]
+!===
+! 0 ! Disable pointer masking for supervisor-mode.
+! N ! Enable pointer masking for supervisor-mode with PMLEN >= N.
+      A call to `sbi_fwft_get()` returns the actual value of PMLEN.
 !===
 |===
 


### PR DESCRIPTION
Allow supervisor software to request that pointer masking be enabled for S-mode. Supervisor software provides a lower bound on PMLEN, which abstracts away which specific pointer masking modes are supported.

This matches the pattern of the [proposed Linux API](https://lore.kernel.org/linux-riscv/20240814081437.956855-5-samuel.holland@sifive.com/) for enabling pointer masking in userspace.