### PR TITLE
Add SBI_ERR_FAILED to several functions

### DIFF
--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -98,6 +98,19 @@ If an SBI function needs to pass a shared memory physical address range to
 the SBI implementation (or higher privilege mode), then this physical memory
 address range MUST satisfy the following requirements:
 
+* The SBI implementation MUST check that the specified physical memory range
+  is composed of valid physical addresses and return SBI_ERR_INVALID_ADDRESS
+  when any address in the range is not valid.
+
+NOTE: A valid address is one that is within the platform's physical memory
+  layout. As an SBI implementation may further restrict the allowed range, it
+  may return a generic SBI_ERR_FAILED (instead of SBI_ERR_INVALID_ADDRESS) when
+  input is invalid with respect to its specific limits. Returning SBI_ERR_FAILED
+  instead of SBI_ERR_INVALID_ADDRESS, in this case, is not a violation of the
+  above specification because the SBI implementation should detect the distinct
+  case of violating the more strict range first, making it appropriate to return
+  the error associated with the stricter range case immediately.
+
 * The SBI implementation MUST check that the supervisor-mode software is
   allowed to access the specified physical memory range with the access
   type requested (read and/or write).

--- a/src/ext-debug-triggers.adoc
+++ b/src/ext-debug-triggers.adoc
@@ -121,6 +121,8 @@ The possible error codes returned in `sbiret.error` are shown in
                             and `shmem_phys_hi` parameters does not satisfy
                             the requirements described in
                             <<_shared_memory_physical_address_range_parameter>>.
+| SBI_ERR_FAILED          | The request failed for unspecified or unknown other
+                            reasons.
 |===
 
 === Function: Read triggers (FID #2)

--- a/src/ext-nested-acceleration.adoc
+++ b/src/ext-nested-acceleration.adoc
@@ -399,6 +399,8 @@ The possible error codes returned in `sbiret.error` are shown in
                             and `shmem_phys_hi` parameters does not satisfy
                             the requirements described in
                             <<_shared_memory_physical_address_range_parameter>>.
+| SBI_ERR_FAILED          | The request failed for unspecified or unknown other
+                            reasons.
 |===
 
 === Function: Synchronize shared memory CSRs (FID #2)

--- a/src/ext-pmu.adoc
+++ b/src/ext-pmu.adoc
@@ -585,6 +585,8 @@ The possible error codes returned in `sbiret.error` are shown in
                             and `shmem_phys_hi` parameters is not writable or
                             does not satisfy other requirements of
                             <<_shared_memory_physical_address_range_parameter>>.
+| SBI_ERR_FAILED          | The request failed for unspecified or unknown other
+                            reasons.
 |===
 
 === Function Listing

--- a/src/ext-sse.adoc
+++ b/src/ext-sse.adoc
@@ -571,6 +571,8 @@ In case of an error, possible error codes are listed in
 | Error code              | Description
 | SBI_SUCCESS             | Event is successfully injected.
 | SBI_ERR_INVALID_PARAM   | `event_id` or `hart_id` is invalid.
+| SBI_ERR_FAILED          | The injection failed for unspecified or unknown other
+                            reasons.
 |===
 
 === Function Listing

--- a/src/ext-sse.adoc
+++ b/src/ext-sse.adoc
@@ -357,6 +357,8 @@ In case of an error, the possible error codes are shown in the
                             `output_phys_lo` and `output_phys_hi` parameters
                             does not satisfy the requirements described in
                             <<_shared_memory_physical_address_range_parameter>>.
+| SBI_ERR_FAILED          | The read failed for unspecified or unknown other
+                            reasons.
 |===
 
 === Function: Write software event attributes (FID #1)
@@ -402,6 +404,8 @@ The possible error codes returned in `sbiret.error` are shown in
                             `input_phys_lo` and `input_phys_hi` parameters
                             does not satisfy the requirements described in
                             <<_shared_memory_physical_address_range_parameter>>.
+| SBI_ERR_FAILED          | The write failed for unspecified or unknown other
+                            reasons.
 |===
 
 === Function: Register a software event (FID #2)


### PR DESCRIPTION
Many functions need SBI_ERR_FAILED with the generic "...failed for
unspecified or unknown other reasons" meaning since SBI implementations
can fail for many [SBI-specific] reasons and it's not reasonable to try
and enumerate them all. A quick audit found the main need is by
functions which take physical address parameters since SBI implementations
may fail on addresses which S-mode knows to be valid (per the platform's
memory layout and ISA), but are not valid for the specific SBI
implementation. Also during the quick audit one SSE function was
identified as needing SBI_ERR_FAILED since event injection has lots of
moving parts.