### PR TITLE
Clarify hart_mask_base requirements

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -52,7 +52,7 @@ jobs:
 
     # Step 4: Upload the built PDF files as a single artifact
     - name: Upload Build Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Build Artifacts
         path: ${{ github.workspace }}/*.pdf

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -89,6 +89,9 @@ Any SBI function, requiring a hart mask, must take the following two arguments:
 * `unsigned long hart_mask_base` is the starting hartid from which the
    bit-vector must be computed.
 
+NOTE: `hart_mask_base` does not need to be an enabled or supervisor available
+hartid unless the zeroth bit of `hart_mask` is set.
+
 In a single SBI function call, the maximum number of harts that can be set is
 always XLEN. If a lower privilege mode needs to pass information about more
 than XLEN harts, it must invoke the SBI function multiple times.
@@ -104,9 +107,9 @@ specific error values.
 [cols="1,2", width=90%, align="center", options="header"]
 |===
 | Error code            | Description
-| SBI_ERR_INVALID_PARAM | Either `hart_mask_base`, or at least one hartid from
-                          `hart_mask`, is not valid, i.e. either the hartid is
-                          not enabled by the platform or is not available to
+| SBI_ERR_INVALID_PARAM | At least one hartid constructed from `hart_mask_base`
+                          and `hart_mask`, is not valid, i.e. either the hartid
+                          is not enabled by the platform or is not available to
                           the supervisor.
 |===
 

--- a/src/ext-ipi.adoc
+++ b/src/ext-ipi.adoc
@@ -25,9 +25,9 @@ The possible error codes returned in `sbiret.error` are shown in the
 |===
 | Error code            | Description
 | SBI_SUCCESS           | IPI was sent to all the targeted harts successfully.
-| SBI_ERR_INVALID_PARAM | Either `hart_mask_base` or at least one hartid from
-                          `hart_mask` is not valid, i.e., either the hartid is
-                          not enabled by the platform or is not available to
+| SBI_ERR_INVALID_PARAM | At least one hartid constructed from `hart_mask_base`
+                          and `hart_mask`, is not valid, i.e. either the hartid
+                          is not enabled by the platform or is not available to
                           the supervisor.
 | SBI_ERR_FAILED        | The request failed for unspecified or unknown other
                           reasons.

--- a/src/ext-rfence.adoc
+++ b/src/ext-rfence.adoc
@@ -29,9 +29,9 @@ The possible error codes returned in `sbiret.error` are shown in the
 |===
 | Error code            | Description
 | SBI_SUCCESS           | IPI was sent to all the targeted harts successfully.
-| SBI_ERR_INVALID_PARAM | Either `hart_mask_base` or at least one hartid from
-                          `hart_mask` is not valid, i.e., either the hartid is
-                          not enabled by the platform or is not available to
+| SBI_ERR_INVALID_PARAM | At least one hartid constructed from `hart_mask_base`
+                          and `hart_mask`, is not valid, i.e. either the hartid
+                          is not enabled by the platform or is not available to
                           the supervisor.
 | SBI_ERR_FAILED        | The request failed for unspecified or unknown other
                           reasons.
@@ -62,10 +62,10 @@ The possible error codes returned in `sbiret.error` are shown in the
 | SBI_SUCCESS             | IPI was sent to all the targeted harts
                             successfully.
 | SBI_ERR_INVALID_ADDRESS | `start_addr` or `size` is not valid.
-| SBI_ERR_INVALID_PARAM   | Either `hart_mask_base` or at least one hartid from
-                            `hart_mask` is not valid, i.e., either the hartid
-                            is not enabled by the platform or is not available
-                            to the supervisor.
+| SBI_ERR_INVALID_PARAM   | At least one hartid constructed from `hart_mask_base`
+                            and `hart_mask`, is not valid, i.e. either the hartid
+                            is not enabled by the platform or is not available to
+                            the supervisor.
 | SBI_ERR_FAILED          | The request failed for unspecified or unknown other
                             reasons.
 |===
@@ -96,10 +96,10 @@ The possible error codes returned in `sbiret.error` are shown in the
 | SBI_SUCCESS             | IPI was sent to all the targeted harts
                             successfully.
 | SBI_ERR_INVALID_ADDRESS | `start_addr` or `size` is not valid.
-| SBI_ERR_INVALID_PARAM   | Either `asid`, `hart_mask_base`, or at least one
-                            hartid from `hart_mask` is not valid, i.e., either
-                            the hartid is not enabled by the platform or is not
-                            available to the supervisor.
+| SBI_ERR_INVALID_PARAM   | Either `asid`, or at least one hartid constructed
+                            from `hart_mask_base` and `hart_mask`, is not valid,
+                            i.e. either the hartid is not enabled by the platform
+                            or is not available to the supervisor.
 | SBI_ERR_FAILED          | The request failed for unspecified or unknown other
                             reasons.
 |===
@@ -134,10 +134,10 @@ The possible error codes returned in `sbiret.error` are shown in the
                             implemented or one of the target hart doesn't
                             support hypervisor extension.
 | SBI_ERR_INVALID_ADDRESS | `start_addr` or `size` is not valid.
-| SBI_ERR_INVALID_PARAM   | Either `vmid`, `hart_mask_base`, or at least one
-                            hartid from `hart_mask` is not valid, i.e., either
-                            the hartid is not enabled by the platform or is not
-                            available to the supervisor.
+| SBI_ERR_INVALID_PARAM   | Either `vmid`, or at least one hartid constructed
+                            from `hart_mask_base` and `hart_mask`, is not valid,
+                            i.e. either the hartid is not enabled by the platform
+                            or is not available to the supervisor.
 | SBI_ERR_FAILED          | The request failed for unspecified or unknown other
                             reasons.
 |===
@@ -171,10 +171,10 @@ The possible error codes returned in `sbiret.error` are shown in the
                             implemented or one of the target hart doesn't
                             support hypervisor extension.
 | SBI_ERR_INVALID_ADDRESS | `start_addr` or `size` is not valid.
-| SBI_ERR_INVALID_PARAM   | Either `hart_mask_base` or at least one hartid from
-                            `hart_mask` is not valid, i.e., either the hartid
-                            is not enabled by the platform or is not available
-                            to the supervisor.
+| SBI_ERR_INVALID_PARAM   | At least one hartid constructed from `hart_mask_base`
+                            and `hart_mask`, is not valid, i.e. either the hartid
+                            is not enabled by the platform or is not available to
+                            the supervisor.
 | SBI_ERR_FAILED          | The request failed for unspecified or unknown other
                             reasons.
 |===
@@ -210,10 +210,10 @@ The possible error codes returned in `sbiret.error` are shown in the
                             implemented or one of the target hart doesn't
                             support hypervisor extension.
 | SBI_ERR_INVALID_ADDRESS | `start_addr` or `size` is not valid.
-| SBI_ERR_INVALID_PARAM   | Either `asid`, `hart_mask_base`, or at least one
-                            hartid from `hart_mask` is not valid, i.e., either
-                            the hartid is not enabled by the platform or is not
-                            available to the supervisor.
+| SBI_ERR_INVALID_PARAM   | Either `asid`, or at least one hartid constructed
+                            from `hart_mask_base` and `hart_mask`, is not valid,
+                            i.e. either the hartid is not enabled by the platform
+                            or is not available to the supervisor.
 | SBI_ERR_FAILED          | The request failed for unspecified or unknown other
                             reasons.
 |===
@@ -247,10 +247,10 @@ The possible error codes returned in `sbiret.error` are shown in the
                             implemented or one of the target hart doesn't
                             support hypervisor extension.
 | SBI_ERR_INVALID_ADDRESS | `start_addr` or `size` is not valid.
-| SBI_ERR_INVALID_PARAM   | Either `hart_mask_base` or at least one hartid from
-                            `hart_mask` is not valid, i.e., either the hartid
-                            is not enabled by the platform or is not available
-                            to the supervisor.
+| SBI_ERR_INVALID_PARAM   | At least one hartid constructed from `hart_mask_base`
+                            and `hart_mask`, is not valid, i.e. either the hartid
+                            is not enabled by the platform or is not available to
+                            the supervisor.
 | SBI_ERR_FAILED          | The request failed for unspecified or unknown other
                             reasons.
 |===


### PR DESCRIPTION
hart_mask_base doesn't need to be valid unless bit0 of hart_mask is set, since the base isn't used independently. Clarify this to ensure implementations don't return SBI_ERR_INVALID_PARAM for invalid hart_mask_base when hart_mask isn't selecting it.