### PR TITLE
Improve legacy extension deprecation notice

### DIFF
--- a/src/ext-legacy.adoc
+++ b/src/ext-legacy.adoc
@@ -14,8 +14,8 @@ The page and access faults taken by the SBI implementation while accessing
 memory on behalf of the supervisor are redirected back to the supervisor
 with `sepc` CSR pointing to the faulting `ECALL` instruction.
 
-The legacy SBI extensions is deprecated in favor of the other extensions
-listed below.
+The legacy SBI extensions are deprecated in favor of the TIME, IPI, RFENCE,
+SRST, and DBCN extensions.
 
 === Extension: Set Timer (EID #0x00)
 


### PR DESCRIPTION
A public review suggestion[1] pointed out a grammar issue (is vs. are) and that it would be better to explicitly list which extensions replace the legacy functions.

Link: https://groups.google.com/a/groups.riscv.org/g/isa-dev/c/g1_vJUXAVZM [1]